### PR TITLE
Fix CDN imports, Safari nav, DOM timing, and dev build pipeline

### DIFF
--- a/build-dev.mjs
+++ b/build-dev.mjs
@@ -1,0 +1,37 @@
+/**
+ * Dev build script — identical to the npm build:css:dev + build:js:dev scripts
+ * but injects the current git commit hash as a banner comment in both outputs
+ * so you can verify which bundle is loaded without checking filenames.
+ *
+ * Usage:  node build-dev.mjs
+ * CI:     set GITHUB_SHA in environment; the first 7 chars are used automatically.
+ */
+
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync } from "fs";
+
+const commit = process.env.GITHUB_SHA
+  ? process.env.GITHUB_SHA.slice(0, 7)
+  : execSync("git rev-parse --short HEAD").toString().trim();
+
+const banner = `/* build: ${commit} */`;
+
+console.log(`Building dev bundle (commit: ${commit})…`);
+
+// Lint (same as build:dev)
+execSync("npm run lint", { stdio: "inherit" });
+
+// CSS
+execSync("npx postcss production/style.css -o dist/bundle.css --map", {
+  stdio: "inherit",
+});
+const css = readFileSync("dist/bundle.css", "utf8");
+writeFileSync("dist/bundle.css", `${banner}\n${css}`);
+
+// JS — esbuild handles the banner natively
+execSync(
+  `npx esbuild production/theme.mjs --bundle --sourcemap --banner:js=${JSON.stringify(banner)} --outfile=dist/bundle.js`,
+  { stdio: "inherit" },
+);
+
+console.log(`Done. Bundle tagged: ${commit}`);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,9 +9,9 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.browser } },
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
 
-  // Node.js config files need Node globals (module, require, process, …)
+  // Node.js config and generator scripts need Node globals (module, require, process, …)
   {
-    files: ["*.config.js", "*.config.mjs", "*.config.cjs"],
+    files: ["*.config.js", "*.config.mjs", "*.config.cjs", "generate_*.js"],
     languageOptions: { globals: globals.node },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig([
 
   // Node.js config and generator scripts need Node globals (module, require, process, …)
   {
-    files: ["*.config.js", "*.config.mjs", "*.config.cjs", "generate_*.js"],
+    files: ["*.config.js", "*.config.mjs", "*.config.cjs", "generate_*.js", "build-*.mjs"],
     languageOptions: { globals: globals.node },
   },
 

--- a/generate_language_file.js
+++ b/generate_language_file.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Scans a folder of course HTML files and writes a sorted JSON array of all
+// Shiki language identifiers found in code blocks to production/data/languages.json.
+//
+// Usage: node generate_language_file.js <path-to-html-folder>
+//
+// Recognises both patterns Skilljar produces:
+//   <pre class="language-terraform"><code data-lang="terraform">
+//   <pre data-lang="terraform"><code>
+
+const { readFileSync, writeFileSync, readdirSync, statSync } = require("fs");
+const { join, extname, resolve } = require("path");
+
+const htmlFolder = process.argv[2];
+
+if (!htmlFolder) {
+  console.error("Usage: node generate_language_file.js <path-to-html-folder>");
+  process.exit(1);
+}
+
+function walkHtml(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...walkHtml(full));
+    } else if (extname(entry) === ".html") {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const patterns = [
+  /class="language-([^"\s]+)"/g,
+  /data-lang="([^"]+)"/g,
+];
+
+const languages = new Set();
+
+for (const file of walkHtml(resolve(htmlFolder))) {
+  const content = readFileSync(file, "utf-8");
+  for (const re of patterns) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(content)) !== null) {
+      languages.add(match[1]);
+    }
+  }
+}
+
+const sorted = [...languages].sort();
+const outputPath = join(__dirname, "production/data/languages.json");
+
+writeFileSync(outputPath, JSON.stringify(sorted, null, 2) + "\n");
+
+console.log(`Found ${sorted.length} language(s): ${sorted.join(", ") || "(none)"}`);
+console.log(`Written to ${outputPath}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
+        "@tsparticles/confetti": "^3.9.1",
+        "shiki": "^4.0.2",
         "terser": "^5.44.1"
       },
       "devDependencies": {
@@ -988,6 +990,106 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -1001,6 +1103,374 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@tsparticles/basic": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-3.9.1.tgz",
+      "integrity": "sha512-ijr2dHMx0IQHqhKW3qA8tfwrR2XYbbWYdaJMQuBo2CkwBVIhZ76U+H20Y492j/NXpd1FUnt2aC0l4CEVGVGdeQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1",
+        "@tsparticles/move-base": "3.9.1",
+        "@tsparticles/plugin-hex-color": "3.9.1",
+        "@tsparticles/plugin-hsl-color": "3.9.1",
+        "@tsparticles/plugin-rgb-color": "3.9.1",
+        "@tsparticles/shape-circle": "3.9.1",
+        "@tsparticles/updater-color": "3.9.1",
+        "@tsparticles/updater-opacity": "3.9.1",
+        "@tsparticles/updater-out-modes": "3.9.1",
+        "@tsparticles/updater-size": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/confetti": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/confetti/-/confetti-3.9.1.tgz",
+      "integrity": "sha512-S0Q6iBqQvcCaOzmnddmh41RHeLwzSdkLq8hU3Ryokmb9eqoS9MQdYz2tjUHHdTap+YLPlp64SZ15sC4C9ulFbA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/basic": "3.9.1",
+        "@tsparticles/engine": "3.9.1",
+        "@tsparticles/plugin-emitters": "3.9.1",
+        "@tsparticles/plugin-motion": "3.9.1",
+        "@tsparticles/shape-cards": "3.9.1",
+        "@tsparticles/shape-emoji": "3.9.1",
+        "@tsparticles/shape-heart": "3.9.1",
+        "@tsparticles/shape-image": "3.9.1",
+        "@tsparticles/shape-polygon": "3.9.1",
+        "@tsparticles/shape-square": "3.9.1",
+        "@tsparticles/shape-star": "3.9.1",
+        "@tsparticles/updater-life": "3.9.1",
+        "@tsparticles/updater-roll": "3.9.1",
+        "@tsparticles/updater-rotate": "3.9.1",
+        "@tsparticles/updater-tilt": "3.9.1",
+        "@tsparticles/updater-wobble": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/engine": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-3.9.1.tgz",
+      "integrity": "sha512-DpdgAhWMZ3Eh2gyxik8FXS6BKZ8vyea+Eu5BC4epsahqTGY9V3JGGJcXC6lRJx6cPMAx1A0FaQAojPF3v6rkmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsparticles/move-base": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/move-base/-/move-base-3.9.1.tgz",
+      "integrity": "sha512-X4huBS27d8srpxwOxliWPUt+NtCwY+8q/cx1DvQxyqmTA8VFCGpcHNwtqiN+9JicgzOvSuaORVqUgwlsc7h4pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-emitters": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-3.9.1.tgz",
+      "integrity": "sha512-h7opR8SoFWBmVHceDLJUerLENaPfkJSh2zQYvzmLj2L+V3VLS1QDgty+4QZVeZfqNROmgQw2eLFA5El1E0sqqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hex-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-3.9.1.tgz",
+      "integrity": "sha512-vZgZ12AjUicJvk7AX4K2eAmKEQX/D1VEjEPFhyjbgI7A65eX72M465vVKIgNA6QArLZ1DLs7Z787LOE6GOBWsg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hsl-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-3.9.1.tgz",
+      "integrity": "sha512-jJd1iGgRwX6eeNjc1zUXiJivaqC5UE+SC2A3/NtHwwoQrkfxGWmRHOsVyLnOBRcCPgBp/FpdDe6DIDjCMO715w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-motion": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-motion/-/plugin-motion-3.9.1.tgz",
+      "integrity": "sha512-I/356NHCiMUgFzWjAHYKO7YvBqKtHSktIPgTRruqlruyrAcwzjkT55ZQ1K5EcJLWETkF1bfG2VpJBRu8ksf9mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-rgb-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-3.9.1.tgz",
+      "integrity": "sha512-SBxk7f1KBfXeTnnklbE2Hx4jBgh6I6HOtxb+Os1gTp0oaghZOkWcCD2dP4QbUu7fVNCMOcApPoMNC8RTFcy9wQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-cards": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-cards/-/shape-cards-3.9.1.tgz",
+      "integrity": "sha512-/tQtGh6xC3UmKU2WO7VM5RoAnsvFvPkXcCJJHAQ6AIyWUKVWBrVuewF0ZbJQlNhWCEW/aqE199LuDAewqYAQ5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-circle": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-3.9.1.tgz",
+      "integrity": "sha512-DqZFLjbuhVn99WJ+A9ajz9YON72RtCcvubzq6qfjFmtwAK7frvQeb6iDTp6Ze9FUipluxVZWVRG4vWTxi2B+/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-emoji": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-3.9.1.tgz",
+      "integrity": "sha512-ifvY63usuT+hipgVHb8gelBHSeF6ryPnMxAAEC1RGHhhXfpSRWMtE6ybr+pSsYU52M3G9+TF84v91pSwNrb9ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-heart": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-heart/-/shape-heart-3.9.1.tgz",
+      "integrity": "sha512-h1aYiBVCUAJ14zyK792EuX0332Hus6OgYy/4dk6PhfgdFTQaHk+FzGJjw+jEB8vpxOYtWeysT9uoofPZeDrqBQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-image": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-3.9.1.tgz",
+      "integrity": "sha512-fCA5eme8VF3oX8yNVUA0l2SLDKuiZObkijb0z3Ky0qj1HUEVlAuEMhhNDNB9E2iELTrWEix9z7BFMePp2CC7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-polygon": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-3.9.1.tgz",
+      "integrity": "sha512-dA77PgZdoLwxnliH6XQM/zF0r4jhT01pw5y7XTeTqws++hg4rTLV9255k6R6eUqKq0FPSW1/WBsBIl7q/MmrqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-square": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-3.9.1.tgz",
+      "integrity": "sha512-DKGkDnRyZrAm7T2ipqNezJahSWs6xd9O5LQLe5vjrYm1qGwrFxJiQaAdlb00UNrexz1/SA7bEoIg4XKaFa7qhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-star": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-3.9.1.tgz",
+      "integrity": "sha512-kdMJpi8cdeb6vGrZVSxTG0JIjCwIenggqk0EYeKAwtOGZFBgL7eHhF2F6uu1oq8cJAbXPujEoabnLsz6mW8XaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-color/-/updater-color-3.9.1.tgz",
+      "integrity": "sha512-XGWdscrgEMA8L5E7exsE0f8/2zHKIqnTrZymcyuFBw2DCB6BIV+5z6qaNStpxrhq3DbIxxhqqcybqeOo7+Alpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-life": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-3.9.1.tgz",
+      "integrity": "sha512-Oi8aF2RIwMMsjssUkCB6t3PRpENHjdZf6cX92WNfAuqXtQphr3OMAkYFJFWkvyPFK22AVy3p/cFt6KE5zXxwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-opacity": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-3.9.1.tgz",
+      "integrity": "sha512-w778LQuRZJ+IoWzeRdrGykPYSSaTeWfBvLZ2XwYEkh/Ss961InOxZKIpcS6i5Kp/Zfw0fS1ZAuqeHwuj///Osw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-out-modes": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-3.9.1.tgz",
+      "integrity": "sha512-cKQEkAwbru+hhKF+GTsfbOvuBbx2DSB25CxOdhtW2wRvDBoCnngNdLw91rs+0Cex4tgEeibkebrIKFDDE6kELg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-roll": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-3.9.1.tgz",
+      "integrity": "sha512-zl4JeM3gUBJ0uttmIsond3lrZ3f3AkItFeS0Lhj/7jiCKfUoRyyOMrcBk8R1AhW7lI+7ko1iBs3jhO0jnxz9vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-rotate": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-3.9.1.tgz",
+      "integrity": "sha512-9BfKaGfp28JN82MF2qs6Ae/lJr9EColMfMTHqSKljblwbpVDHte4umuwKl3VjbRt87WD9MGtla66NTUYl+WxuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-size": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-3.9.1.tgz",
+      "integrity": "sha512-3NSVs0O2ApNKZXfd+y/zNhTXSFeG1Pw4peI8e6z/q5+XLbmue9oiEwoPy/tQLaark3oNj3JU7Q903ZijPyXSzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-tilt": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-3.9.1.tgz",
+      "integrity": "sha512-PB2yaoyXRmSk4iIVgjtRrzOxXMK9mjeAQHIJGtT4faq46Z8cbIIEFgjTwqrUV8qOrNg/h4sm5NE/s0qsTYjp1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-wobble": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-3.9.1.tgz",
+      "integrity": "sha512-c99Ogy9q4QWO+zsDXol0UnpUwZiY2UucFb8ltuDv9AlbGUeprygoub8jhgT5pEDv+GdzWOJGSgq7rfgv9cHBrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -1008,12 +1478,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1317,6 +1817,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1332,6 +1842,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -1413,6 +1943,16 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -1697,6 +2237,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-serializer": {
@@ -2402,6 +2964,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hookified": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.14.0.tgz",
@@ -2420,6 +3018,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -2763,6 +3371,27 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -2792,6 +3421,95 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -2881,6 +3599,23 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/optionator": {
@@ -3681,6 +4416,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3747,6 +4492,30 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3867,6 +4636,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3940,6 +4728,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3953,6 +4751,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -4453,6 +5265,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4477,6 +5299,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -4536,6 +5426,34 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4661,6 +5579,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "stylelint-order": "^7.0.1"
   },
   "dependencies": {
+    "@tsparticles/confetti": "^3.9.1",
+    "shiki": "^4.0.2",
     "terser": "^5.44.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch:js": "esbuild production/theme.mjs --bundle --sourcemap --outfile=dist/bundle.js --watch",
     "generate:langs": "node generate_language_file.js",
     "build": "npm run lint && npm run build:css && npm run build:js",
-    "build:dev": "npm run lint && npm run build:css:dev && npm run build:js:dev",
+    "build:dev": "node build-dev.mjs",
     "dev": "npm run watch:css & npm run watch:js",
     "test": "node --test"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:js:dev": "esbuild production/theme.mjs --bundle --sourcemap --outfile=dist/bundle.js",
     "watch:css": "postcss production/style.css -o dist/bundle.css --watch --map",
     "watch:js": "esbuild production/theme.mjs --bundle --sourcemap --outfile=dist/bundle.js --watch",
+    "generate:langs": "node generate_language_file.js",
     "build": "npm run lint && npm run build:css && npm run build:js",
     "build:dev": "npm run lint && npm run build:css:dev && npm run build:js:dev",
     "dev": "npm run watch:css & npm run watch:js",

--- a/production/css/lessons.css
+++ b/production/css/lessons.css
@@ -142,7 +142,7 @@ body.sj-page-lesson {
   #lp-left-nav {
     position: fixed; /* fixed so it stays at the viewport edge and doesn't scroll away */
     top: 60px !important; /* Skilljar Override: cbp-spmenu sets top: 0, we need below fixed header */
-    left: 0;
+    left: 0 !important; /* Skilljar Override: cbp-spmenu sets left: -320px which breaks transform-based animation in Safari */
     display: flex !important; /* Skilljar Override: cbp-spmenu sets display: block */
     flex-direction: column !important; /* Skilljar Override: pin badge to bottom of nav */
     width: 292px; /* formerly 320px; */

--- a/production/data/languages.json
+++ b/production/data/languages.json
@@ -1,0 +1,17 @@
+[
+  "ansi",
+  "bash",
+  "console",
+  "docker",
+  "dockerfile",
+  "go",
+  "http",
+  "json",
+  "markdown",
+  "markup",
+  "nginx",
+  "python",
+  "terraform",
+  "text",
+  "yaml"
+]

--- a/production/skilljar-theme-v3.0/CG.mjs
+++ b/production/skilljar-theme-v3.0/CG.mjs
@@ -321,26 +321,25 @@ export const CG = {
   dom: {
     local: {},
     body: document.body,
-    bodyHeader: Q("#header"),
-    headerLeft: Q("#header-left"),
-    headerRight: Q("#header-right"),
-    courseBoxes: A(".coursebox-container"),
+    get bodyHeader() { return Q("#header"); },
+    get headerLeft() { return Q("#header-left"); },
+    get headerRight() { return Q("#header-right"); },
+    get courseBoxes() { return A(".coursebox-container"); },
 
     get contentContainer() {
       return CG.page.isLesson ? Q(".sj-page-lesson") : Q("#skilljar-content");
     },
 
     header: {
-      wrapper: Q(".cp-summary-wrapper") || Q(".dp-summary-wrapper"),
-      courseInfo: Q(".sj-course-info-wrapper") || Q(".sj-heading-paragraph"),
-      ctaBtnWrapper: Q("#resume-button") || Q("#purchase-button-wrapper-large"),
-      registerBtn: Q("#purchase-button-wrapper-large a"),
-      ctaBtn: Q("#resume-button a"),
-      ctaBtnText: Q("#resume-button a span"),
-      btn:
-        Q("a.resume-button") ||
-        Q("a.purchase-button") ||
-        Q("a#path-curriculum-resume-button"),
+      get wrapper() { return Q(".cp-summary-wrapper") || Q(".dp-summary-wrapper"); },
+      get courseInfo() { return Q(".sj-course-info-wrapper") || Q(".sj-heading-paragraph"); },
+      get ctaBtnWrapper() { return Q("#resume-button") || Q("#purchase-button-wrapper-large"); },
+      get registerBtn() { return Q("#purchase-button-wrapper-large a"); },
+      get ctaBtn() { return Q("#resume-button a"); },
+      get ctaBtnText() { return Q("#resume-button a span"); },
+      get btn() {
+        return Q("a.resume-button") || Q("a.purchase-button") || Q("a#path-curriculum-resume-button");
+      },
 
       get links() {
         if (!this.courseInfo) return [];
@@ -371,8 +370,8 @@ export const CG = {
         return "#";
       },
     },
-    courseContainer: Q("#dp-details") || Q("#cp-content"),
-    curriculumContainer: A("ul.dp-curriculum")[0] || Q("div#curriculum-list"),
+    get courseContainer() { return Q("#dp-details") || Q("#cp-content"); },
+    get curriculumContainer() { return A("ul.dp-curriculum")[0] || Q("div#curriculum-list"); },
   },
 
   data: {

--- a/production/skilljar-theme-v3.0/CG.mjs
+++ b/production/skilljar-theme-v3.0/CG.mjs
@@ -21,7 +21,7 @@ export const CG = {
     hasCourse: typeof skilljarCourse !== "undefined",
     hasCatalogPage: typeof skilljarCatalogPage !== "undefined",
     hasCourseProgress: typeof skilljarCourseProgress !== "undefined",
-    hasCourseBoxes: A(".coursebox-container").length > 0,
+    get hasCourseBoxes() { return A(".coursebox-container").length > 0; },
 
     get isAdmin() {
       if (!this.isLoggedIn) return false;
@@ -57,16 +57,16 @@ export const CG = {
     },
   },
   page: {
-    isLogin: c(".sj-page-login"),
-    isSignup: c(".sj-page-signup"),
-    is404: c(".sj-page-error-404"),
-    isCatalog: c(".sj-page-catalog"),
-    isLanding: c(".sj-page-catalog-root"),
-    isCourseUnregistered: c(".sj-page-detail-course"),
-    isCourseRegistered: c(".sj-page-curriculum"),
-    isPathUnregistered: c(".sj-page-detail-path"), // Removed: .sj-page-detail-bundle
-    isPathRegistered: c(".sj-page-path"), // Removed: .sj-page-series
-    isLesson: c(".sj-page-lesson"),
+    get isLogin() { return c(".sj-page-login"); },
+    get isSignup() { return c(".sj-page-signup"); },
+    get is404() { return c(".sj-page-error-404"); },
+    get isCatalog() { return c(".sj-page-catalog"); },
+    get isLanding() { return c(".sj-page-catalog-root"); },
+    get isCourseUnregistered() { return c(".sj-page-detail-course"); },
+    get isCourseRegistered() { return c(".sj-page-curriculum"); },
+    get isPathUnregistered() { return c(".sj-page-detail-path"); }, // Removed: .sj-page-detail-bundle
+    get isPathRegistered() { return c(".sj-page-path"); }, // Removed: .sj-page-series
+    get isLesson() { return c(".sj-page-lesson"); },
     isPartner404:
       [
         "/page/partners",

--- a/production/skilljar-theme-v3.0/CG.mjs
+++ b/production/skilljar-theme-v3.0/CG.mjs
@@ -320,7 +320,7 @@ export const CG = {
   },
   dom: {
     local: {},
-    body: document.body,
+    get body() { return document.body; },
     get bodyHeader() { return Q("#header"); },
     get headerLeft() { return Q("#header-left"); },
     get headerRight() { return Q("#header-right"); },

--- a/production/skilljar-theme-v3.0/course-completion.mjs
+++ b/production/skilljar-theme-v3.0/course-completion.mjs
@@ -7,10 +7,10 @@ import { setStyle } from "./styling.mjs";
 import { CG } from "./CG.mjs";
 import { logger } from "./logger.mjs";
 
-// External libraries — dynamic import so esbuild doesn't wrap this CDN URL in a
-// require() shim (which throws in browsers). The promise resolves eagerly so
-// shoot() pays no latency penalty on first call.
-const confettiLoader = import("https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.0.3/+esm")
+// External libraries — Function() bypasses esbuild's static import() → require()
+// transform in IIFE mode, letting the browser's native dynamic import handle the
+// CDN URL. Requires unsafe-eval in CSP.
+const confettiLoader = Function('u', 'return import(u)')("https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.0.3/+esm")
   .then(m => m.confetti);
 
 // static imports

--- a/production/skilljar-theme-v3.0/course-completion.mjs
+++ b/production/skilljar-theme-v3.0/course-completion.mjs
@@ -7,8 +7,11 @@ import { setStyle } from "./styling.mjs";
 import { CG } from "./CG.mjs";
 import { logger } from "./logger.mjs";
 
-// External libraries
-import { confetti } from "https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.0.3/+esm";
+// External libraries — dynamic import so esbuild doesn't wrap this CDN URL in a
+// require() shim (which throws in browsers). The promise resolves eagerly so
+// shoot() pays no latency penalty on first call.
+const confettiLoader = import("https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.0.3/+esm")
+  .then(m => m.confetti);
 
 // static imports
 import { config } from "../data/config.mjs";
@@ -128,7 +131,8 @@ export function hideCompletion(elem) {
  * Shoot confetti bursts with stars, circles, and logos.
  * @returns {void}
  */
-export function shoot(size = "big", { x, y } = { x: 0.5, y: 0.33 }) {
+export async function shoot(size = "big", { x, y } = { x: 0.5, y: 0.33 }) {
+  const confetti = await confettiLoader;
   const configConfetti = { ...config.confetti.defaults, origin: { x, y } };
   logger.info("Shooting confetti", configConfetti);
 

--- a/production/skilljar-theme-v3.0/course-completion.mjs
+++ b/production/skilljar-theme-v3.0/course-completion.mjs
@@ -7,11 +7,7 @@ import { setStyle } from "./styling.mjs";
 import { CG } from "./CG.mjs";
 import { logger } from "./logger.mjs";
 
-// External libraries — Function() bypasses esbuild's static import() → require()
-// transform in IIFE mode, letting the browser's native dynamic import handle the
-// CDN URL. Requires unsafe-eval in CSP.
-const confettiLoader = Function('u', 'return import(u)')("https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.0.3/+esm")
-  .then(m => m.confetti);
+import { confetti } from "@tsparticles/confetti";
 
 // static imports
 import { config } from "../data/config.mjs";
@@ -131,8 +127,7 @@ export function hideCompletion(elem) {
  * Shoot confetti bursts with stars, circles, and logos.
  * @returns {void}
  */
-export async function shoot(size = "big", { x, y } = { x: 0.5, y: 0.33 }) {
-  const confetti = await confettiLoader;
+export function shoot(size = "big", { x, y } = { x: 0.5, y: 0.33 }) {
   const configConfetti = { ...config.confetti.defaults, origin: { x, y } };
   logger.info("Shooting confetti", configConfetti);
 

--- a/production/skilljar-theme-v3.0/router.mjs
+++ b/production/skilljar-theme-v3.0/router.mjs
@@ -49,7 +49,21 @@ export function route() {
     logger.info(`Running page styling handler: ${match.handler.name}`);
     match.handler();
   } else {
-    logger.warn("No page styling handler matched for this page.");
+    logger.error("No page styling handler matched for this page.", {
+      url: window.location.href,
+      page: {
+        isLesson: CG.page.isLesson,
+        isCourseRegistered: CG.page.isCourseRegistered,
+        isCourseUnregistered: CG.page.isCourseUnregistered,
+        isPathRegistered: CG.page.isPathRegistered,
+        isPathUnregistered: CG.page.isPathUnregistered,
+        isCatalog: CG.page.isCatalog,
+        isLanding: CG.page.isLanding,
+        isLogin: CG.page.isLogin,
+        isSignup: CG.page.isSignup,
+        is404: CG.page.is404,
+      },
+    });
   }
 }
 

--- a/production/skilljar-theme-v3.0/views/lesson.mjs
+++ b/production/skilljar-theme-v3.0/views/lesson.mjs
@@ -11,8 +11,9 @@ import {
   cleanCommandPrompt,
 } from "../code-utils.mjs";
 
-// Shiki syntax highlighting
-import * as shiki from "https://esm.sh/shiki@3.0.0";
+// Shiki syntax highlighting — lazy dynamic import so esbuild doesn't wrap this
+// CDN URL in a require() shim. The promise is cached after the first call.
+let shikiLoader = null;
 
 // static imports
 import { config } from "../../data/config.mjs";
@@ -133,6 +134,8 @@ function addCopyButton(pre, codeEl) {
  * @returns {Promise<void>} A promise that resolves when formatting is complete.
  */
 const formatCode = async (code, lang) => {
+  if (!shikiLoader) shikiLoader = import("https://esm.sh/shiki@3.0.0");
+  const shiki = await shikiLoader;
   const parser = new DOMParser();
 
   // Apply Shiki highlighting

--- a/production/skilljar-theme-v3.0/views/lesson.mjs
+++ b/production/skilljar-theme-v3.0/views/lesson.mjs
@@ -11,7 +11,42 @@ import {
   cleanCommandPrompt,
 } from "../code-utils.mjs";
 
-import * as shiki from "shiki";
+// Fine-grained shiki imports — only the languages from production/data/languages.json
+// and the theme set in config.mjs. Add langs here if languages.json changes.
+import { createHighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import langBash from "shiki/langs/bash.mjs";
+import langConsole from "shiki/langs/console.mjs";
+import langDocker from "shiki/langs/docker.mjs";
+import langDockerfile from "shiki/langs/dockerfile.mjs";
+import langGo from "shiki/langs/go.mjs";
+import langHtml from "shiki/langs/html.mjs";
+import langHttp from "shiki/langs/http.mjs";
+import langJson from "shiki/langs/json.mjs";
+import langMarkdown from "shiki/langs/markdown.mjs";
+import langNginx from "shiki/langs/nginx.mjs";
+import langPython from "shiki/langs/python.mjs";
+import langTerraform from "shiki/langs/terraform.mjs";
+import langYaml from "shiki/langs/yaml.mjs";
+import themeMinLight from "shiki/themes/min-light.mjs";
+
+// "markup" is a Prism.js alias for HTML; "ansi" and "text" have no shiki equivalent
+// (formatCode returns early for unsupported langs, leaving the code block as-is)
+const LANG_ALIASES = { markup: "html" };
+const SUPPORTED_LANGS = new Set([
+  "bash", "console", "docker", "dockerfile", "go", "html",
+  "http", "json", "markdown", "nginx", "python", "terraform", "yaml",
+]);
+
+const highlighterPromise = createHighlighterCore({
+  themes: [themeMinLight],
+  langs: [
+    langBash, langConsole, langDocker, langDockerfile, langGo, langHtml,
+    langHttp, langJson, langMarkdown, langNginx, langPython, langTerraform,
+    langYaml,
+  ],
+  engine: createJavaScriptRegexEngine(),
+});
 
 // static imports
 import { config } from "../../data/config.mjs";
@@ -132,15 +167,17 @@ function addCopyButton(pre, codeEl) {
  * @returns {Promise<void>} A promise that resolves when formatting is complete.
  */
 const formatCode = async (code, lang) => {
+  const normalizedLang = LANG_ALIASES[lang] ?? lang;
+  if (!SUPPORTED_LANGS.has(normalizedLang)) return;
+
+  const highlighter = await highlighterPromise;
   const parser = new DOMParser();
 
-  // Apply Shiki highlighting
-  const formatted = await shiki.codeToHtml(
-    // trim textContent to avoid extra newlines
+  const formatted = highlighter.codeToHtml(
     code.textContent.trim(),
     {
-      lang,
-      theme: config.codeTheme || "github-light",
+      lang: normalizedLang,
+      theme: config.codeTheme || "min-light",
       transformers: [addLineNumberSpans()],
     },
   );
@@ -148,8 +185,7 @@ const formatCode = async (code, lang) => {
   let newCode = Q("code", parser.parseFromString(formatted, "text/html"));
 
   if (newCode) {
-    // replace old code element with new highlighted one
-    newCode.classList = code.classList; // preserve original classes
+    newCode.classList = code.classList;
     code.replaceWith(newCode);
   }
 };

--- a/production/skilljar-theme-v3.0/views/lesson.mjs
+++ b/production/skilljar-theme-v3.0/views/lesson.mjs
@@ -134,7 +134,7 @@ function addCopyButton(pre, codeEl) {
  * @returns {Promise<void>} A promise that resolves when formatting is complete.
  */
 const formatCode = async (code, lang) => {
-  if (!shikiLoader) shikiLoader = import("https://esm.sh/shiki@3.0.0");
+  if (!shikiLoader) shikiLoader = Function('u', 'return import(u)')("https://esm.sh/shiki@3.0.0");
   const shiki = await shikiLoader;
   const parser = new DOMParser();
 

--- a/production/skilljar-theme-v3.0/views/lesson.mjs
+++ b/production/skilljar-theme-v3.0/views/lesson.mjs
@@ -490,6 +490,17 @@ export function lessonView() {
     elem.href = sanitizeUrl(elem.href);
   });
 
+  // Mirrors open/closed state on both body and #lp-left-nav so our CSS
+  // (body.cbp-spmenu-open) and Skilljar's CSS (#lp-left-nav.cbp-spmenu-open)
+  // both agree. Also persists the preference to localStorage so the state
+  // survives page loads in browsers where Skilljar's own JS doesn't run (Safari).
+  function setNavOpen(open) {
+    document.body.classList.toggle("cbp-spmenu-open", open);
+    if (CG.dom.local.nav.menu)
+      CG.dom.local.nav.menu.classList.toggle("cbp-spmenu-open", open);
+    try { localStorage.setItem("lessonNavStateOpen", open ? "true" : "false"); } catch { /* storage unavailable */ }
+  }
+
   // Build the nav toggle bar: use Skilljar's if present, otherwise create our own
   if (!CG.dom.local.nav.toggleWrapper) {
     const navBar = el("a", {
@@ -498,7 +509,7 @@ export function lessonView() {
       on: {
         click: (e) => {
           e.preventDefault();
-          document.body.classList.toggle("cbp-spmenu-open");
+          setNavOpen(!document.body.classList.contains("cbp-spmenu-open"));
         }
       }
     }, [
@@ -508,10 +519,12 @@ export function lessonView() {
     CG.dom.local.nav.toggleWrapper = navBar;
   }
 
-  // Open the sidebar by default on desktop
-  if (window.matchMedia("(min-width: 992px)").matches) {
-    document.body.classList.add("cbp-spmenu-open");
-  }
+  // Restore nav state: respect stored preference; default to open on desktop
+  const storedNavState = localStorage.getItem("lessonNavStateOpen");
+  const navShouldOpen = storedNavState !== null
+    ? storedNavState === "true"
+    : window.matchMedia("(min-width: 992px)").matches;
+  setNavOpen(navShouldOpen);
 
   // Close the nav when tapping the backdrop on mobile
   CG.dom.local.body.mainContainer.addEventListener("click", (e) => {
@@ -519,7 +532,7 @@ export function lessonView() {
       document.body.classList.contains("cbp-spmenu-open") &&
       !CG.dom.local.nav.menu.contains(e.target) &&
       !CG.dom.local.nav.toggleWrapper.contains(e.target)) {
-      document.body.classList.remove("cbp-spmenu-open");
+      setNavOpen(false);
     }
   });
 

--- a/production/skilljar-theme-v3.0/views/lesson.mjs
+++ b/production/skilljar-theme-v3.0/views/lesson.mjs
@@ -459,7 +459,7 @@ export function lessonView() {
       body: Q("#lesson-body"),
       innerBody: Q("#lesson-main-inner"),
       content: {
-        codeBlocks: A("pre:has(code):not(.language-ansi)"),
+        codeBlocks: A("pre:not(.language-ansi)").filter(el => el.querySelector("code")),
         inlineCodeBlocks: A("code[data-lang]"),
         internalCourseWarning: Q("#internal-course-warning"),
         links: A("sjwc-lesson-content-item a"),
@@ -493,13 +493,12 @@ export function lessonView() {
   // Build the nav toggle bar: use Skilljar's if present, otherwise create our own
   if (!CG.dom.local.nav.toggleWrapper) {
     const navBar = el("a", {
-      id: "left-nav-button", href: "#", aria: {
-        label: "Toggle course navigation",
-        on: {
-          click: (e) => {
-            e.preventDefault();
-            document.body.classList.toggle("cbp-spmenu-open");
-          }
+      id: "left-nav-button", href: "#",
+      aria: { label: "Toggle course navigation" },
+      on: {
+        click: (e) => {
+          e.preventDefault();
+          document.body.classList.toggle("cbp-spmenu-open");
         }
       }
     }, [

--- a/production/skilljar-theme-v3.0/views/lesson.mjs
+++ b/production/skilljar-theme-v3.0/views/lesson.mjs
@@ -11,9 +11,7 @@ import {
   cleanCommandPrompt,
 } from "../code-utils.mjs";
 
-// Shiki syntax highlighting — lazy dynamic import so esbuild doesn't wrap this
-// CDN URL in a require() shim. The promise is cached after the first call.
-let shikiLoader = null;
+import * as shiki from "shiki";
 
 // static imports
 import { config } from "../../data/config.mjs";
@@ -134,8 +132,6 @@ function addCopyButton(pre, codeEl) {
  * @returns {Promise<void>} A promise that resolves when formatting is complete.
  */
 const formatCode = async (code, lang) => {
-  if (!shikiLoader) shikiLoader = Function('u', 'return import(u)')("https://esm.sh/shiki@3.0.0");
-  const shiki = await shikiLoader;
   const parser = new DOMParser();
 
   // Apply Shiki highlighting

--- a/production/theme.mjs
+++ b/production/theme.mjs
@@ -17,14 +17,20 @@ import { CG } from "./skilljar-theme-v3.0/CG.mjs";
 import { showBody } from "./skilljar-theme-v3.0/styling.mjs";
 import { route, preRoute, postRoute } from "./skilljar-theme-v3.0/router.mjs";
 import { setupDebug } from "./skilljar-theme-v3.0/debug.mjs";
+import { logger } from "./skilljar-theme-v3.0/logger.mjs";
 
 document.addEventListener("DOMContentLoaded", () => {
-  if (CG.env.isAdmin) setupDebug();
+  try {
+    if (CG.env.isAdmin) setupDebug();
 
-  preRoute();
-  route();
-  postRoute();
-
-  // show all
-  showBody();
+    preRoute();
+    route();
+    postRoute();
+  } catch (err) {
+    logger.error("Theme setup failed — page will render unstyled.", err);
+  } finally {
+    // Always show the body; preload.js hides it to prevent FOUC and we must
+    // re-show it regardless of whether the theme applied successfully.
+    showBody();
+  }
 });

--- a/production/theme.mjs
+++ b/production/theme.mjs
@@ -22,15 +22,24 @@ import { logger } from "./skilljar-theme-v3.0/logger.mjs";
 document.addEventListener("DOMContentLoaded", () => {
   try {
     if (CG.env.isAdmin) setupDebug();
-
     preRoute();
+  } catch (err) {
+    logger.error("Theme setup failed in preRoute().", err);
+  }
+
+  try {
     route();
+  } catch (err) {
+    logger.error("Theme setup failed in route().", err);
+  }
+
+  try {
     postRoute();
   } catch (err) {
-    logger.error("Theme setup failed — page will render unstyled.", err);
-  } finally {
-    // Always show the body; preload.js hides it to prevent FOUC and we must
-    // re-show it regardless of whether the theme applied successfully.
-    showBody();
+    logger.error("Theme setup failed in postRoute().", err);
   }
+
+  // Always show the body; preload.js hides it to prevent FOUC and we must
+  // re-show it regardless of whether the theme applied successfully.
+  showBody();
 });


### PR DESCRIPTION
## Summary

This PR resolves a series of cascading bugs that prevented the dev bundle from working, plus a Safari-specific navigation regression discovered in the process.

### CDN imports → npm packages

- Replaced runtime CDN `import()` calls for `@tsparticles/confetti` and `shiki` with proper npm dependencies. esbuild's IIFE output converts all `import()` to `require()` shims, so CDN URL imports threw `Dynamic require of "URL" is not supported` at runtime; CSP `unsafe-eval` also blocked the `Function()` workaround.
- Used fine-grained shiki imports (`shiki/core`, per-language `.mjs` files) instead of the full `shiki` bundle, keeping the output at ~2 MB instead of ~9.9 MB.
- Added `generate_language_file.js` to scan lesson HTML for language identifiers and emit `production/data/languages.json` so the language list stays in sync with content.

### DOM timing (esbuild IIFE runs before DOMContentLoaded)

- Converted all eagerly-evaluated properties in `CG.dom`, `CG.page`, and `CG.env` to getter accessors so DOM queries only run at call time, not at module parse time.
- Split the single `DOMContentLoaded` handler into three separate try/catch blocks (`preRoute`, `route`, `postRoute`) so a failure in one phase doesn't silently swallow the others. `showBody()` is called unconditionally afterward to prevent a permanently hidden page.
- Changed the \"no handler matched\" log from `logger.warn` to `logger.error` with a full page-state dump.

### Safari/Dia navigation fix

- Skilljar's native `#left-nav-button` exists in Chrome's DOM at `DOMContentLoaded` but not in Safari, so our custom toggle button only fires in Safari. The `on:` handler was nested inside `aria:` in the `el()` call, producing `aria-on=\"[object Object]\"` in the HTML instead of attaching a click listener — fixed by moving `on:` to the top level.
- Skilljar's CSS sets `left: -320px` on `#lp-left-nav.cbp-spmenu:not(.cbp-spmenu-open)` with higher specificity than our rule. Added `left: 0 !important` to our base `#lp-left-nav` rule so the `transform`-based open/close animation is not overridden.
- Introduced `setNavOpen(open)` which mirrors `cbp-spmenu-open` on both `body` (for our CSS) and `#lp-left-nav` (for Skilljar's CSS), and persists the state to `localStorage.lessonNavStateOpen` so the user's preference survives page loads in any browser.

### `hideCompletion` event listener

- `hideCompletion()` was passing `on: { transitionend: … }` to `setStyle()`, which does not handle event listeners — the `transitionend` callback was never attached. Replaced with native `addEventListener`/`removeEventListener` plus a 300 ms safety timeout.

### Dev build pipeline

- Added `.github/workflows/sync-dev-gcs.yaml` — triggers on pushes to `dev` with changes under `production/**` or `fonts/**`, builds without minification, and syncs only to `gs://chainguard-courses-theme/dev/dist/`.
- Added `build-dev.mjs` which injects the short commit SHA as a `/* build: <hash> */` banner in both `bundle.js` and `bundle.css`, making it easy to verify which bundle is loaded in the browser without checking filenames.

## Test plan

- [x] Lesson page loads without console errors in Chrome, Safari, and Dia
- [x] Left nav is visible on desktop load in Safari and Dia (reads `localStorage.lessonNavStateOpen`; defaults to open)
- [x] Nav toggle opens and closes the sidebar in all three browsers; state persists across page reloads
- [x] Code blocks are syntax-highlighted (shiki) on lesson pages
- [x] Course completion popup fires confetti and dismisses correctly (click, ESC, auto-hide)
- [x] `/* build: <hash> */` banner appears on line 1 of the deployed `bundle.js` and `bundle.css`
- [x] Production build (`npm run build`) still lints and minifies cleanly