### PR TITLE
fix(ci): add zizmor pedantic persona and suppress noisy findings

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,17 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 
@@ -42,3 +48,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,18 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Zizmor configuration for courses-theme.
+# CI runs zizmor with --pedantic; rules with no security value are disabled
+# to keep CI signal-to-noise high. See PSEC-923 for rationale.
+
+rules:
+  # Pedantic-only; no security impact — cosmetic/style findings
+  anonymous-definition:
+    disable: true
+  # Pedantic-only; no security impact — documentation style
+  undocumented-permissions:
+    disable: true
+  # Pedantic-only; low security value but extremely noisy
+  # Address concurrency limits as a separate, dedicated effort if desired
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This single-patch series adds the `persona: pedantic` configuration to the
zizmor CI workflow and suppresses three noisy pedantic-only rules that have
no direct security value, reducing CI noise while maintaining full coverage
of security-relevant findings.

## Patches

### 0001 — fix(ci): add pedantic persona and suppress noisy zizmor rules

Adds `.github/zizmor.yml` with the following rule configuration:

- `anonymous-definition: disable: true` — pedantic-only, purely cosmetic
  (5 findings suppressed)
- `undocumented-permissions: disable: true` — pedantic-only, documentation
  style only, no security impact (3 findings suppressed)
- `concurrency-limits: disable: true` — pedantic-only, low security value,
  extremely noisy (4 findings suppressed)

Also updates `.github/workflows/zizmor.yaml` to:
- Pass `--pedantic` to zizmor-action so the CI run actually enforces the
  pedantic persona (previously ran at `regular` persona)
- Extend the `paths:` trigger to include `.github/zizmor.yml` and
  `.github/dependabot.yaml` so that changes to those files re-trigger the
  zizmor check

## Findings addressed

| Rule | Count | Disposition |
|------|-------|-------------|
| `anonymous-definition` | 5 | Disabled in zizmor.yml (no security impact) |
| `concurrency-limits` | 4 | Disabled in zizmor.yml (low security value) |
| `undocumented-permissions` | 3 | Disabled in zizmor.yml (style only) |

## Testing

After merging, open a PR that modifies `.github/zizmor.yml` to verify the
paths trigger fires. The zizmor check should pass with zero findings (the
previously-noisy rules are now suppressed).

Refs: PSEC-923